### PR TITLE
Game ends when missing

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,9 +101,6 @@
   const POWER_IDEAL = 0.65;
   const POWER_MIN_STICK = 0.2, POWER_MAX_STICK = 0.95;
 
-  // Throws/Scoring
-  const START_THROWS = 5;
-
   // Misc
   const RESULT_SHOW_TIME = 2000; // ms
 
@@ -120,7 +117,8 @@
   let assetLoadErrorAxe = false, assetLoadErrorGorg = false;
 
   // Game
-  let score = 0, throwsLeft = START_THROWS;
+  let score = 0;
+  let lastThrowMissed = false;
   let resultMsg = '', resultPoints = 0;
   let showResultTimer = 0;
 
@@ -272,12 +270,11 @@
       case STATE_SHOWING_RESULT:
         showResultTimer -= dt * 1000;
         if (showResultTimer <= 0) {
-          if (throwsLeft > 0) {
-            // Reset for next throw
+          if (lastThrowMissed) {
+            state = STATE_GAME_OVER;
+          } else {
             state = STATE_AIM_HORIZONTAL;
             resetForNextThrow();
-          } else {
-            state = STATE_GAME_OVER;
           }
         }
         break;
@@ -298,8 +295,6 @@
     ctx.fillStyle = "#1a1a1d";
     ctx.textAlign = "left";
     ctx.fillText("Score: " + score, 22, 36);
-    ctx.textAlign = "right";
-    ctx.fillText("Throws Left: " + throwsLeft, CANVAS_WIDTH - 22, 36);
     ctx.restore();
 
     // Center target
@@ -556,11 +551,11 @@
           startThrow();
           break;
         case STATE_SHOWING_RESULT:
-          if (throwsLeft > 0) {
+          if (lastThrowMissed) {
+            state = STATE_GAME_OVER;
+          } else {
             state = STATE_AIM_HORIZONTAL;
             resetForNextThrow();
-          } else {
-            state = STATE_GAME_OVER;
           }
           break;
         case STATE_GAME_OVER:
@@ -624,9 +619,11 @@
     }
     if (resultPoints > 0) {
       sliderSpeedMultiplier *= 1.2;
+      lastThrowMissed = false;
+    } else {
+      lastThrowMissed = true;
     }
     score += resultPoints;
-    throwsLeft--;
 
     showResultTimer = RESULT_SHOW_TIME;
     state = STATE_SHOWING_RESULT;
@@ -636,10 +633,10 @@
 
   function resetGame() {
     score = 0;
-    throwsLeft = START_THROWS;
     resultMsg = '';
     resultPoints = 0;
     sliderSpeedMultiplier = 1;
+    lastThrowMissed = false;
     resetForNextThrow();
   }
   function resetForNextThrow() {
@@ -657,6 +654,7 @@
     axeAngle = 0;
     axeHitX = TARGET_X;
     axeHitY = TARGET_Y;
+    lastThrowMissed = false;
   }
 </script>
 </body>


### PR DESCRIPTION
## Summary
- remove turn limit and end the game when the player misses
- keep speeding up sliders after successful throws
- clean up UI to remove `Throws Left`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841f63bbc08832f8a495a77c2ffe393