### PR TITLE
Allow tap anywhere to trigger slider lock

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,12 +37,6 @@
       font-size: 1.08rem;
       letter-spacing: .5px;
     }
-    #tapButton {
-      margin: 20px auto;
-      padding: 10px 18px;
-      font-size: 1.1rem;
-      display: block;
-    }
     @media (max-width: 850px) {
       #gameCanvas { width: 97vw; height: 72vw; max-width:800px; max-height:600px; }
     }
@@ -52,9 +46,8 @@
   <h1>Axe Throwing Challenge</h1>
   <canvas id="gameCanvas" width="800" height="600"></canvas>
   <div id="instructions">
-    Use <b>SPACEBAR</b> or tap the button below to lock each slider and throw.
+    Use <b>SPACEBAR</b> or tap anywhere on the screen to lock each slider and throw.
   </div>
-  <button id="tapButton">Tap to Stop</button>
 <script>
   // ==== Constants ====
   const CANVAS_WIDTH = 800, CANVAS_HEIGHT = 600;
@@ -157,15 +150,12 @@
     loadImages();
 
     window.addEventListener('keydown', handleInput);
-    const tapBtn = document.getElementById('tapButton');
-    if (tapBtn) {
-      function triggerTap(e) {
-        e.preventDefault(); // prevent 300ms click delay and synthetic click
-        handleInput({ code: 'Space', preventDefault: function(){} });
-      }
-      tapBtn.addEventListener('touchstart', triggerTap);
-      tapBtn.addEventListener('click', triggerTap);
+    function triggerTap(e) {
+      e.preventDefault(); // prevent 300ms click delay and synthetic click
+      handleInput({ code: 'Space', preventDefault: function(){} });
     }
+    window.addEventListener('touchstart', triggerTap);
+    window.addEventListener('click', triggerTap);
     requestAnimationFrame(gameLoop);
   };
 


### PR DESCRIPTION
## Summary
- remove unused tap button and styles
- listen for touch/click events on the window instead
- update on-screen instructions

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_6842569f19c8832fa9077925aa54a5cd