### PR TITLE
Ensure axe sticks vertically

### DIFF
--- a/index.html
+++ b/index.html
@@ -685,6 +685,8 @@
     score += resultPoints;
 
     showResultTimer = RESULT_SHOW_TIME;
+    // Keep the axe vertical after it lands
+    axeAngle = 0;
     state = STATE_SHOWING_RESULT;
   }
 


### PR DESCRIPTION
## Summary
- reset rotation after evaluating a throw so the axe sticks vertically

## Testing
- `tidy -e index.html`

------
https://chatgpt.com/codex/tasks/task_e_68428884c568832fbea24eaa4ddb9a38