### PR TITLE
Fix placeholder name

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
 
   // ==== Globals ====
   let canvas, ctx, bulletButtonEl;
-  let targetName = 'Pablo';
+  let targetName = '';
 
   let state = STATE_LOADING;
 


### PR DESCRIPTION
## Summary
- remove the default `Pablo` name so nothing shows before a player enters a name

## Testing
- `tidy -e index.html`

------
https://chatgpt.com/codex/tasks/task_e_6842fbac6398832f8a00ae4f5070e400