### PR TITLE
Fix lock in followup sequence

### DIFF
--- a/index.html
+++ b/index.html
@@ -963,6 +963,7 @@
     lockInActive = false;
     lockQueue = 3;
     state = lockPrevState;
+    resetForNextThrow();
     startBullseyeThrow();
   }
 


### PR DESCRIPTION
## Summary
- reset game state before launching the lock reward sequence

## Testing
- `tidy -e index.html`

------
https://chatgpt.com/codex/tasks/task_e_68436b5dbef0832fb8965924af32b93b