### PR TITLE
Add simple debug console

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,20 @@
       font-size: 1rem;
       display: none;
     }
+    #debugConsole {
+      width: 90%;
+      max-width: 800px;
+      height: 120px;
+      margin: 20px auto 0;
+      padding: 8px;
+      background: #1e1e1e;
+      color: #0f0;
+      font-family: monospace;
+      font-size: 0.85rem;
+      overflow-y: auto;
+      white-space: pre-wrap;
+      display: none;
+    }
     @media (max-width: 850px) {
       #gameCanvas { width: 97vw; }
     }
@@ -166,7 +180,8 @@
   <div id="instructions">
     Use <b>SPACEBAR</b> or <span id="touchInstruction">tap the button below</span> to lock each slider and throw. Use the BULLET TIME button once per game to slow the sliders. Use the AXE BARRAGE button once to unleash five random throws. Use the LOCK IN button once for a chance at three perfect hits.
   </div>
-<script>
+  <div id="debugConsole"></div>
+  <script>
   // ==== Constants ====
   let CANVAS_WIDTH = 800, CANVAS_HEIGHT = 600;
 
@@ -244,7 +259,7 @@
   const RESULT_SHOW_TIME = 2000; // ms
 
   // ==== Globals ====
-  let canvas, ctx, bulletButtonEl, multiButtonEl, lockButtonEl, lockPromptEl, restartButtonEl;
+  let canvas, ctx, bulletButtonEl, multiButtonEl, lockButtonEl, lockPromptEl, restartButtonEl, debugConsoleEl;
   let targetName = '';
 
   let state = STATE_LOADING;
@@ -308,11 +323,37 @@
   // For random offset/accuracy
   let throw_random_dx = 0, throw_random_dy = 0;
 
+  function initDebugConsole() {
+    if (!debugConsoleEl) return;
+    window.addEventListener('error', e => {
+      logDebug(`Error: ${e.message} at ${e.filename}:${e.lineno}`);
+    });
+    window.addEventListener('unhandledrejection', e => {
+      logDebug(`Unhandled rejection: ${e.reason}`);
+    });
+    const origError = console.error;
+    console.error = function(...args) {
+      origError.apply(console, args);
+      logDebug('Console error: ' + args.join(' '));
+    };
+  }
+
+  function logDebug(msg) {
+    if (!debugConsoleEl) return;
+    debugConsoleEl.style.display = 'block';
+    const div = document.createElement('div');
+    div.textContent = msg;
+    debugConsoleEl.appendChild(div);
+    debugConsoleEl.scrollTop = debugConsoleEl.scrollHeight;
+  }
+
   // ----
 
   window.onload = function() {
     canvas = document.getElementById('gameCanvas');
     ctx = canvas.getContext('2d');
+    debugConsoleEl = document.getElementById('debugConsole');
+    initDebugConsole();
     const nameOverlayEl = document.getElementById('nameOverlay');
     const nameInputEl = document.getElementById('nameInput');
     const nameSubmitEl = document.getElementById('nameSubmit');


### PR DESCRIPTION
## Summary
- add console element to display runtime errors
- hook up `window.onerror`, `unhandledrejection` and `console.error` to populate the console

## Testing
- `tidy -e index.html`

------
https://chatgpt.com/codex/tasks/task_e_6843746c6f64832f9e3216341bb0a8a5