### PR TITLE
Fix lock challenge timing error

### DIFF
--- a/index.html
+++ b/index.html
@@ -609,6 +609,10 @@
           }
         }
         break;
+      case STATE_LOCK_CHALLENGE:
+        lockTimer -= dt * 1000;
+        if (lockTimer <= 0) failLockChallenge();
+        break;
       case STATE_GAME_OVER:
         // Wait for user to press Space to reset
         break;
@@ -671,8 +675,6 @@
         ctx.restore();
         break;
       case STATE_LOCK_CHALLENGE:
-        lockTimer -= dt * 1000;
-        if (lockTimer <= 0) failLockChallenge();
         break;
       case STATE_GAME_OVER:
         ctx.save();


### PR DESCRIPTION
## Summary
- move lock timer updates into `update()`
- keep drawing logic separate in `draw()`

## Testing
- `tidy -e index.html`

------
https://chatgpt.com/codex/tasks/task_e_684376028008832fa262d6ca5fdf0d1f